### PR TITLE
Make sure os.environ.items() isn't unicode

### DIFF
--- a/posix_spawn/_impl.py
+++ b/posix_spawn/_impl.py
@@ -83,8 +83,10 @@ def _posix_spawn(posix_spawn_variant, path, args,
     pid = ffi.new("pid_t *")
 
     if env is None:
-        env = getattr(os, 'environb', os.environ)
-
+        env = getattr(os, 'environb', False)
+        if env is False:
+            env = dict((key.encode('utf-8'), value.encode('utf-8')) for (key, value) in os.environ.items())
+        
     if file_actions is None:
         file_actions = ffi.NULL
     else:


### PR DESCRIPTION
Hi,

I recently ran into an issue (on pypy) where os.environ actually contained unicode, not string. This chokes `ffi.new("char[]")`. The solution was to pass a blank environment, or use this patch. 

Feel free to accept it, or let me know if you want a pull request on a slightly updated README to highlight this corner case.

Regards,
Niklas